### PR TITLE
[VSI-1913] SagaStateRepository changed to use only ID (no Type); enforcing ID to be GUID; v.4.0.1

### DIFF
--- a/src/Chronicle.Tests/Builders/ChronicleBuilderTests.cs
+++ b/src/Chronicle.Tests/Builders/ChronicleBuilderTests.cs
@@ -68,7 +68,7 @@ namespace Chronicle.Tests.Builders
 
         public class MySagaLog : ISagaLog
         {
-            public Task<IEnumerable<ISagaLogData>> ReadAsync(SagaId id, Type type)
+            public Task<IEnumerable<ISagaLogData>> ReadAsync(SagaId id)
             {
                 throw new NotImplementedException();
             }
@@ -81,7 +81,7 @@ namespace Chronicle.Tests.Builders
 
         public class MySagaStateRepository : ISagaStateRepository
         {
-            public Task<ISagaState> ReadAsync(SagaId id, Type type)
+            public Task<ISagaState> ReadAsync(SagaId id)
             {
                 throw new NotImplementedException();
             }

--- a/src/Chronicle/Chronicle.csproj
+++ b/src/Chronicle/Chronicle.csproj
@@ -12,6 +12,7 @@
       <PackageLicenseUrl>https://github.com/chronicle-stack/Chronicle/blob/master/LICENSE</PackageLicenseUrl>
       <PackageIconUrl>https://avatars1.githubusercontent.com/u/42150754?s=200</PackageIconUrl>
       <Version>4.0.0</Version>
+      <Version>4.0.0-alpha.1</Version>
       <AssemblyVersion>3.2.1.0</AssemblyVersion>
       <FileVersion>3.2.1.0</FileVersion>
       <LangVersion>latest</LangVersion>

--- a/src/Chronicle/Chronicle.csproj
+++ b/src/Chronicle/Chronicle.csproj
@@ -11,8 +11,7 @@
       <PackageProjectUrl>https://github.com/chronicle-stack/Chronicle</PackageProjectUrl>
       <PackageLicenseUrl>https://github.com/chronicle-stack/Chronicle/blob/master/LICENSE</PackageLicenseUrl>
       <PackageIconUrl>https://avatars1.githubusercontent.com/u/42150754?s=200</PackageIconUrl>
-      <Version>4.0.0</Version>
-      <Version>4.0.0-alpha.1</Version>
+      <Version>4.0.1</Version>
       <AssemblyVersion>3.2.1.0</AssemblyVersion>
       <FileVersion>3.2.1.0</FileVersion>
       <LangVersion>latest</LangVersion>

--- a/src/Chronicle/ISagaLog.cs
+++ b/src/Chronicle/ISagaLog.cs
@@ -6,7 +6,7 @@ namespace Chronicle
 {
     public interface ISagaLog
     {
-        Task<IEnumerable<ISagaLogData>> ReadAsync(SagaId id, Type type);
+        Task<IEnumerable<ISagaLogData>> ReadAsync(SagaId id);
         Task WriteAsync(ISagaLogData message);
     }
 }

--- a/src/Chronicle/ISagaStateRepository.cs
+++ b/src/Chronicle/ISagaStateRepository.cs
@@ -1,11 +1,10 @@
-using System;
 using System.Threading.Tasks;
 
 namespace Chronicle
 {
     public interface ISagaStateRepository
     {
-        Task<ISagaState> ReadAsync(SagaId id, Type type);
+        Task<ISagaState> ReadAsync(SagaId id);
         Task WriteAsync(ISagaState state);
     }
 }

--- a/src/Chronicle/Managers/SagaInitializer.cs
+++ b/src/Chronicle/Managers/SagaInitializer.cs
@@ -20,7 +20,7 @@ namespace Chronicle.Managers
             var sagaType = saga.GetType();
             var dataType = saga.GetSagaDataType();
             
-            var state = await _repository.ReadAsync(id, sagaType).ConfigureAwait(false);
+            var state = await _repository.ReadAsync(id).ConfigureAwait(false);
 
             if (state is null)
             {

--- a/src/Chronicle/Managers/SagaPostProcessor.cs
+++ b/src/Chronicle/Managers/SagaPostProcessor.cs
@@ -33,7 +33,7 @@ namespace Chronicle.Managers
         
         private async Task CompensateAsync(ISaga saga, Type sagaType, ISagaContext context)
         {
-            var sagaLogs = await _log.ReadAsync(saga.Id, sagaType);
+            var sagaLogs = await _log.ReadAsync(saga.Id);
             sagaLogs.OrderByDescending(l => l.CreatedAt)
                 .Select(l => l.Message)
                 .ToList()

--- a/src/Chronicle/Persistence/InMemorySagaStateRepository.cs
+++ b/src/Chronicle/Persistence/InMemorySagaStateRepository.cs
@@ -1,26 +1,18 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Chronicle.Persistence
 {
     public class InMemorySagaStateRepository : ISagaStateRepository
     {
-        private readonly List<ISagaState> _repository;
+        private readonly Dictionary<SagaId, ISagaState> _repository = [];
 
-        public InMemorySagaStateRepository() => _repository = new List<ISagaState>();
-
-        public Task<ISagaState> ReadAsync(SagaId id, Type type) 
-            => Task.FromResult(_repository.FirstOrDefault(s => s.Id == id && s.Type == type));
+        public Task<ISagaState> ReadAsync(SagaId id) 
+            => Task.FromResult(_repository.TryGetValue(id, out var value) ? value : null);
 
         public async Task WriteAsync(ISagaState state)
         {
-            var sagaDataToUpdate = await ReadAsync(state.Id, state.Type);
-
-            _repository.Remove(sagaDataToUpdate);
-            _repository.Add(state);
-
+            _repository[state.Id] = state;
             await Task.CompletedTask;
         }
     }

--- a/src/Chronicle/SagaId.cs
+++ b/src/Chronicle/SagaId.cs
@@ -1,22 +1,24 @@
-﻿using System;
+using System;
 
 namespace Chronicle
 {
-    public struct SagaId
+    public readonly struct SagaId(Guid id)
     {
-        public string Id { get; }
+        public Guid Id => id;
 
-        private SagaId(string id)
-            => Id = id;
+        public static implicit operator Guid(SagaId sagaId) => sagaId.Id;
+        public static implicit operator SagaId(Guid sagaId) => new(sagaId);
 
-        public static implicit operator string(SagaId sagaId) => sagaId.Id;
+        public static bool operator ==(SagaId lhs, SagaId rhs) => lhs.Id == rhs.Id;
+        public static bool operator !=(SagaId lhs, SagaId rhs) => !(lhs == rhs);
 
-        public static implicit operator SagaId(string sagaId)
-            => new SagaId(sagaId);
+        public static SagaId NewSagaId() => new(Guid.NewGuid());
+        public static SagaId FromString(string str) =>
+            Guid.TryParse(str, out var guid) ? guid :
+            throw new ChronicleException("String for SagaId must be GUID.");
 
-        public static SagaId NewSagaId()
-            => new SagaId(Guid.NewGuid().ToString());
-
-        public override string ToString() => Id;
+        public override string ToString() => Id.ToString();
+        public override bool Equals(object obj) => obj is SagaId other && this == other;
+        public override int GetHashCode() => Id.GetHashCode();
     }
 }


### PR DESCRIPTION
```
MOD SagaId struct
    - made readonly
    - Id property changed type from string to Guid
    - string cast operators changed into Guid cast operators (still implicit)
    - added operators == !=
    - overriden ToString, Equals, GetHashCode
    - added FromString static method (throws exception if string is not parsable to Guid)

MOD ISagaStateRepository, ISagaLog
    - ReadAsync method loses Type argument
MOD InMemorySagaStateRepository, InMemorySagaLog
    - ReadAsync method loses Type argument
    - Data kept in Dictionaries (key = Id) instead of Lists
    - adjusted ReadAsync & WriteAsync methods to use dictionary

MOD SagaInitializer, SagaPostProcessor
    - modified ReadAsync usages to match new interface
    
MOD MySagaStateRepository, MySagaLog (in ChronicleBuilderTests)
    - ReadAsync method loses Type argument
```